### PR TITLE
Fix: Support tagged/wildcard trade offers

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -1,0 +1,25 @@
+name: .NET
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: '10.0.x'
+
+    - name: Restore dependencies
+      run: dotnet restore
+
+    - name: Build
+      run: dotnet build --no-restore
+
+    - name: Test
+      run: dotnet test --no-build --verbosity normal

--- a/Extensions.cs
+++ b/Extensions.cs
@@ -1,4 +1,6 @@
-﻿using Eco.Gameplay.Components.Store;
+﻿using Eco.Gameplay.Components;
+using Eco.Gameplay.Components.Store;
+using Eco.Gameplay.Items;
 using Eco.Gameplay.Players;
 using Eco.Gameplay.Settlements;
 using Eco.Gameplay.Systems.Messaging.Notifications;
@@ -15,6 +17,24 @@ namespace TradeAssistant
 {
     public static class Extensions
     {
+        public static IEnumerable<int> OfferedItemTypeIDs(this TradeOffer offer)
+        {
+            if (offer.Stack?.Item != null)
+                return new[] { offer.Stack.Item.TypeID };
+
+            return Item.AllItemsExceptHidden
+                .Where(offer.MeetsSpecialRequirements)
+                .Select(i => i.TypeID);
+        }
+
+        public static bool MatchesTypeID(this TradeOffer offer, int typeID)
+        {
+            if (offer.Stack?.Item != null)
+                return offer.Stack.Item.TypeID == typeID;
+
+            return offer.MeetsSpecialRequirements(Item.Get(typeID));
+        }
+
         public static void TempServerMessage(this User user, StringBuilder message, NotificationCategory category = NotificationCategory.Notifications, NotificationStyle style = NotificationStyle.Chat)
         {
             TempServerMessage(user, message.ToStringLoc(), category, style);

--- a/TradeAssistantCalculator.cs
+++ b/TradeAssistantCalculator.cs
@@ -49,11 +49,13 @@ namespace TradeAssistant
             Config = config;
 
             StoreBuyPrices = store.StoreData.BuyOffers
-                .GroupBy(o => o.Stack.Item.TypeID)
+                .SelectMany(o => o.OfferedItemTypeIDs().Select(typeID => new { typeID, o.Price }))
+                .GroupBy(x => x.typeID)
                 .ToDictionary(x => x.Key, x => x.Max(o => o.Price));
 
             StoreSellPrices = store.StoreData.SellOffers
-                .GroupBy(o => o.Stack.Item.TypeID)
+                .SelectMany(o => o.OfferedItemTypeIDs().Select(typeID => new { typeID, o.Price }))
+                .GroupBy(x => x.typeID)
                 .ToDictionary(x => x.Key, x => x.Min(o => o.Price));
         }
 
@@ -428,9 +430,9 @@ namespace TradeAssistant
             StoreSellPrices[item.TypeID] = newPrice;
 
             var msgs = new List<LocString>();
-            Store.StoreData.SellOffers.Where(o => o.Stack.Item.TypeID == item.TypeID && o.Price != newPrice).ForEach(o =>
+            Store.StoreData.SellOffers.Where(o => o.MatchesTypeID(item.TypeID) && o.Price != newPrice).ForEach(o =>
             {
-                msgs.AddLoc($"Updating sell price of {item.UILink()} from {Text.StyledNum(o.Price)} to {Text.StyledNum(newPrice)}");
+                msgs.AddLoc($"{Text.Positive(Localizer.DoStr("Updating sell price"))} of {item.UILink()} from {Text.StyledNum(o.Price)} to {Text.StyledNum(newPrice)}");
                 o.Price = newPrice;
             });
             return msgs;
@@ -443,9 +445,9 @@ namespace TradeAssistant
             StoreBuyPrices[item.TypeID] = newPrice;
 
             var msgs = new List<LocString>();
-            Store.StoreData.BuyOffers.Where(o => o.Stack.Item.TypeID == item.TypeID && o.Price != newPrice).ForEach(o =>
+            Store.StoreData.BuyOffers.Where(o => o.MatchesTypeID(item.TypeID) && o.Price != newPrice).ForEach(o =>
             {
-                msgs.AddLoc($"Updating buy price of {item.UILink()} from {Text.StyledNum(o.Price)} to {Text.StyledNum(newPrice)}");
+                msgs.AddLoc($"{Text.Positive(Localizer.DoStr("Updating buy price"))} of {item.UILink()} from {Text.StyledNum(o.Price)} to {Text.StyledNum(newPrice)}");
                 o.Price = newPrice;
             });
             return msgs;

--- a/TradeAssistantCommandHandler.cs
+++ b/TradeAssistantCommandHandler.cs
@@ -46,27 +46,39 @@ namespace TradeAssistant
             
             var sb = new StringBuilder();
 
-            var items = calc.CraftableItems.SelectMany(x => x.Value).Select(p => p.TypeID).ToHashSet();
-            var soldItems = calc.Store.StoreData.SellOffers.Select(o => o.Stack.Item.TypeID).ToHashSet();
-            var itemsToAdd = items.Where(i => !soldItems.Contains(i)).Where(i => StrangeWorldsPlugin.Obj.Config.AllowPaidItemsInPlayerStores || !i.IsPaidItem()).ToList();
+            var soldItems = calc.Store.StoreData.SellOffers.SelectMany(o => o.OfferedItemTypeIDs()).ToHashSet();
+            var plannedAdds = new HashSet<int>();
+            var tableToItemsToAdd = new List<(LocString table, List<int> itemIds)>();
+
+            foreach (var (table, tableItems) in calc.CraftableItems)
+            {
+                var uniqueForThisTable = tableItems
+                    .Select(i => i.TypeID)
+                    .Where(i => StrangeWorldsPlugin.Obj.Config.AllowPaidItemsInPlayerStores || !i.IsPaidItem())
+                    .Where(i => !soldItems.Contains(i))
+                    .Where(plannedAdds.Add)
+                    .ToList();
+
+                if (uniqueForThisTable.Count > 0)
+                    tableToItemsToAdd.Add((table, uniqueForThisTable));
+            }
+
+            var itemsToAdd = plannedAdds.ToList();
 
             if (!itemsToAdd.Any())
             {
-                sb.AppendLine(Localizer.DoStr($"All the items you can craft is already added to the store."));
+                sb.AppendLine(Localizer.DoStr($"All the items you can craft are already added to this store."));
                 user.TempServerMessage(sb);
                 return;
             }
 
-            foreach (var (table, tableItems) in calc.CraftableItems)
+            foreach (var (table, itemIds) in tableToItemsToAdd)
             {
-                var addedForThisTable = tableItems.Select(i => i.TypeID).Where(itemsToAdd.Contains);
-                if (!addedForThisTable.Any()) { continue; }
-
-                calc.Store.CreateCategoryWithOffers(user.Player, addedForThisTable.ToList(), false);
+                calc.Store.CreateCategoryWithOffers(user.Player, itemIds, false);
                 var category = calc.Store.StoreData.SellCategories.Last();
                 category.Name = table;
             }
-            foreach (var offer in calc.Store.StoreData.SellOffers.Where(o => itemsToAdd.Contains(o.Stack.Item.TypeID)))
+            foreach (var offer in calc.Store.StoreData.SellOffers.Where(o => itemsToAdd.Any(o.MatchesTypeID)))
                 offer.Price = 999999;
 
             sb.AppendLine(Localizer.DoStr($"Added {Text.Info(Text.Num(itemsToAdd.Count))} sell orders. Open the store and remove the items you're not interested in selling at your shop."));
@@ -88,7 +100,7 @@ namespace TradeAssistant
             var allRecipes = calc.ProductToRequiredItemsLookup();
 
             // Limit the products to only the ones we're selling
-            var sellOfferTypeIds = calc.Store.StoreData.SellOffers.Select(o => o.Stack.Item.TypeID).ToList();
+            var sellOfferTypeIds = calc.Store.StoreData.SellOffers.SelectMany(o => o.OfferedItemTypeIDs()).ToHashSet();
 
             // Work through the list of craftable items and find the product we need to make them
             var todo = new Queue<int>(calc.CraftableItems.SelectMany(x => x.Value).Select(p => p.TypeID).Distinct().Where(sellOfferTypeIds.Contains));
@@ -96,22 +108,30 @@ namespace TradeAssistant
             while (todo.TryDequeue(out var productId))
             {
                 if (!done.Add(productId)) continue;
-                var itemsToQueue = allRecipes[productId].Where(allRecipes.ContainsKey).ToList();
-                var itemsToBuy = allRecipes[productId].Where(i => !itemsToQueue.Contains(i));
+                if (!allRecipes.TryGetValue(productId, out var recipeIngredients))
+                    continue;
+
+                var itemsToQueue = recipeIngredients.Where(allRecipes.ContainsKey).ToList();
+                var itemsToBuy = recipeIngredients.Where(i => !itemsToQueue.Contains(i));
                 items.AddRange(itemsToBuy);
                 itemsToQueue.ForEach(todo.Enqueue);
             }
 
-            items.RemoveRange(calc.Store.StoreData.BuyOffers.Select(o => o.Stack.Item.TypeID));
+            var existingBuyOrderTypeIds = calc.Store.StoreData.BuyOffers.SelectMany(o => o.OfferedItemTypeIDs()).ToHashSet();
+            var existingOrderTypeIds = existingBuyOrderTypeIds.Union(sellOfferTypeIds).ToHashSet();
+            var duplicateOrderCount = items.RemoveWhere(existingOrderTypeIds.Contains);
             if (items.Count == 0)
             {
-                user.TempServerMessage(Localizer.DoStr($"The buy orders for all possible ingredients to make the current sell order products are already listed in the shop."));
+                if (duplicateOrderCount > 0)
+                    user.TempServerMessage(Localizer.DoStr($"No new buy orders were added because all required ingredients already exist as store orders."));
+                else
+                    user.TempServerMessage(Localizer.DoStr($"All buy orders to make the current sell order products are already listed in this shop."));
                 return;
             }
 
 
             calc.Store.CreateCategoryWithOffers(user.Player, items.ToList(), true);
-            foreach (var offer in calc.Store.StoreData.BuyOffers.Where(o => items.Contains(o.Stack.Item.TypeID)))
+            foreach (var offer in calc.Store.StoreData.BuyOffers.Where(o => items.Any(o.MatchesTypeID)))
             {
                 offer.Limit = 1;
                 offer.Price = 0;
@@ -126,13 +146,21 @@ namespace TradeAssistant
             var calc = await TradeAssistantCalculator.TryInitialize(user);
             if (calc == null) return;
 
-            var storeSellItemIds = calc.Store.StoreData.SellOffers.Where(o => !calc.Config.FrozenSellPrices.Contains(o.Stack.Item.TypeID)).Select(o => o.Stack.Item.TypeID).Distinct().ToList();
+            var storeSellItemIds = calc.Store.StoreData.SellOffers
+                .SelectMany(o => o.OfferedItemTypeIDs())
+                .Where(typeID => !calc.Config.FrozenSellPrices.Contains(typeID))
+                .Distinct()
+                .ToList();
             if (storeSellItemIds.Count == 0)
             {
                 user.TempServerMessage(Localizer.Do($"{calc.Store.Parent.UILink()} has no sell orders."));
                 return;
             }
-            var buyProductsToUpdate = calc.Store.StoreData.BuyOffers.Select(o => o.Stack.Item.TypeID).Distinct().Where(storeSellItemIds.Contains).ToList();
+            var buyProductsToUpdate = calc.Store.StoreData.BuyOffers
+                .SelectMany(o => o.OfferedItemTypeIDs())
+                .Distinct()
+                .Where(storeSellItemIds.Contains)
+                .ToList();
 
             var byProducts = calc.Config.ByProducts.ToHashSet();
             var craftableItems = calc.CraftableItems.SelectMany(x => x.Value).Select(x => x.TypeID).Distinct().ToHashSet();
@@ -172,7 +200,9 @@ namespace TradeAssistant
             else
             {
                 output.Insert(0, Localizer.Do($"Updating the sell prices at {calc.Store.Parent.UILink()}\n"));
-                updates.ForEach(u => output.AppendLine(u));
+                updates
+                    .Where(u => !string.IsNullOrWhiteSpace(u))
+                    .ForEach(u => output.AppendLine(u));
                 if (updates.Count > 0)
                     output.AppendLineLoc($"Updated the price(s) of {Text.StyledNum(updates.Count)} order(s)");
                 user.TempServerMessage(output.ToStringLoc());


### PR DESCRIPTION
### Problem

TA crashes or silently ignores store offers that use Eco's "tag" system (offers without a specific item, matching by `MeetsSpecialRequirements` instead). Accessing `o.Stack.Item.TypeID` directly on these offers throws a `NullReferenceException` since `Stack.Item` is `null` for tagged offers.

This affected `/ta setupsell`, `/ta setupbuy`, and `/ta update`, all of which assumed every offer had a concrete item.

### Solution

Added two extension methods on `TradeOffer` in `Extensions.cs`:

- **`OfferedItemTypeIDs()`** returns `[Stack.Item.TypeID]` for specific offers, or all matching item TypeIDs via `MeetsSpecialRequirements` for tagged offers.
- **`MatchesTypeID(int typeID)`** safe equivalent of `Stack.Item.TypeID == typeID`, handles both cases.

Both methods short-circuit on `Stack.Item != null` so concrete offers never call `MeetsSpecialRequirements`, keeping the common path fast.

All direct `o.Stack.Item.TypeID` accesses in `TradeAssistantCalculator.cs` and `TradeAssistantCommandHandler.cs` are replaced with these methods.

### Changes

**`Extensions.cs`**
- Added `OfferedItemTypeIDs()` and `MatchesTypeID()` extension methods on `TradeOffer`

**`TradeAssistantCalculator.cs`**
- `StoreBuyPrices` and `StoreSellPrices` dictionary building now uses `SelectMany(o => o.OfferedItemTypeIDs()...)` to correctly expand tagged offers
- `SetSellPrice` / `SetBuyPrice` use `MatchesTypeID()` instead of direct TypeID comparison
- Price update messages now styled with `Text.Positive()` for better in-game readability
- Empty update messages filtered with `IsNullOrWhiteSpace` guard

**`TradeAssistantCommandHandler.cs`**
- `SetupSell`: refactored to track items per-table, deduplicate across tables, and use `OfferedItemTypeIDs()` / `MatchesTypeID()`
- `SetupBuy`: uses `OfferedItemTypeIDs()` for sell and buy offer lookups
- `Update`: `storeSellItemIds` and `buyProductsToUpdate` queries use `SelectMany(o => o.OfferedItemTypeIDs())`
- Minor grammar fix: `"is already added"` → `"are already added"`

.net yml is optional.
### Testing

Verify with a store that has at least one tagged buy or sell offer (e.g. an offer accepting any `Tag` group). `/ta setupsell`, `/ta setupbuy`, and `/ta update` should all complete without errors and correctly include or price the tagged offer's matching items.

Also verify a store with only concrete-item offers behaves identically to before, no performance regression on the common path.

Tested and working on the AWLGaming live Eco servers.
